### PR TITLE
Add Functionality for Recording Past Happy Things

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -3,5 +3,19 @@
   bottom: 16px;
   right: 16px;
   z-index: 1000;
-  color: $white;
+  color: $pink;
+  background-color: $white;
+  padding: 10px;
+  border-radius: 5px;
+}
+
+.notice {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 1000;
+  color: $pink;
+  background-color: $white;
+  padding: 10px;
+  border-radius: 5px;
 }

--- a/app/controllers/happy_things_controller.rb
+++ b/app/controllers/happy_things_controller.rb
@@ -30,7 +30,7 @@ class HappyThingsController < ApplicationController
 
   def update
     if @happy_thing.update(happy_thing_params)
-      redirect_to root_path, notice: "Yay! 🎉 Happy Thing was successfully updated. 🥰"
+      redirect_to root_path, notice: "Yay! 🎉 Happy Thing was updated 🥰"
     else
       render :edit, status: 422
     end
@@ -38,12 +38,25 @@ class HappyThingsController < ApplicationController
 
   def destroy
     @happy_thing.destroy
-    redirect_to root_path, notice: "Oh no! Happy Thing was destroyed. 😕"
+    redirect_to root_path, notice: "Happy Thing was destroyed 😕"
   end
 
   def show_by_date
     @date = Date.parse(params[:date])
     @happy_things = HappyThing.where(start_time: @date.beginning_of_day..@date.end_of_day)
+  end
+
+  def old_happy_thing
+    @old_happy_thing = current_user.happy_things.new
+  end
+
+  def create_old_happy_thing
+    @old_happy_thing = current_user.happy_things.build(happy_thing_params)
+    if @old_happy_thing.save!
+      redirect_to root_path, notice: "Yay! 🎉 Old Happy Thing was successfully created."
+    else
+      render :old, status: 422
+    end
   end
 
   private
@@ -53,6 +66,6 @@ class HappyThingsController < ApplicationController
   end
 
   def happy_thing_params
-    params.require(:happy_thing).permit(:title, :body, :status, :date, :time)
+    params.require(:happy_thing).permit(:title, :body, :status, :start_time)
   end
 end

--- a/app/models/happy_thing.rb
+++ b/app/models/happy_thing.rb
@@ -2,9 +2,15 @@ class HappyThing < ApplicationRecord
   belongs_to :user
   validates :title, presence: true
   default_scope { order(created_at: :desc) }
-  before_create :add_date_time_to_happy_thing
+  before_create :add_date_time_to_happy_thing, unless: :start_time_present?
 
   def add_date_time_to_happy_thing
     self.start_time = DateTime.now
+  end
+
+  private
+
+  def start_time_present?
+    start_time.present?
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -34,7 +34,7 @@
     <%# ? HappyThings %>
     <div class="m-2 mt-5">
       <h3 class="mb-3">Your Happy Things of today</h3>
-      <%= render @happy_things.where("DATE(created_at) = ?", Date.today).reverse %>
+      <%= render @happy_things.where("DATE(start_time) = ?", Date.today).reverse %>
     </div>
   <% end %>
 
@@ -47,14 +47,19 @@
         <p><%= line %></p>
       <% end %>
     <% else %>
-      <p>Sorry, could not find a poem of that author today 🙁</p>
+      <p>Sorry, could not find a poem today 🙁</p>
     <% end %>
   </div>
 
     <%# ? Today one year ago Section %>
     <div class="m-2 mt-5">
       <h3 class="mb-3">On this day...</h3>
-      <p>Coming Soon</p>
+        <p>Coming Soon</p>
+    </div>
+
+    <div class="m-2 mt-5">
+      <h3 class="mb-3">Forgot something?</h3>
+        <%= link_to 'Add an Old Happy Thing', old_happy_thing_path, class: "btn shadow" %>
     </div>
 
   <%= link_to 'See all Happy Things', happy_things_path, class: "btn btn-blue mt-4" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,10 +13,6 @@
         { radius: :max }
         ] unless @user.avatar.key.nil? %>
       <%= f.input :avatar, as: :file %>
-      <%= f.input :first_name %>
-      <%= f.input :last_name %>
-      <%= f.input :emoji %>
-      <%= f.input :email, required: true, autofocus: true %>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
@@ -29,6 +25,8 @@
                   hint: "What's your first name?",
                   required: false,
                   input_html: { autocomplete: "new-password" } %>
+      <%= f.input :emoji %>
+      <%= f.input :email, required: true, autofocus: true %>
       <%= f.input :password,
                   hint: "leave it blank if you don't want to change it",
                   required: false,
@@ -38,7 +36,7 @@
                   input_html: { autocomplete: "new-password" } %>
       <%= f.input :current_password,
                   hint: "we need your current password to confirm your changes",
-                  required: true,
+                  required: false,
                   input_html: { autocomplete: "current-password" } %>
     </div>
 

--- a/app/views/happy_things/old_happy_thing.html.erb
+++ b/app/views/happy_things/old_happy_thing.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <%= link_to sanitize("&larr; Back to happy things"), happy_things_path %>
+
+  <div class="header">
+    <h1>Add an old happy thing</h1>
+  </div>
+
+  <%= simple_form_for @old_happy_thing, url: old_happy_thing_path do |f| %>
+    <%= f.input :title, label: 'Title' %>
+    <%= f.input :start_time %>
+    <%= f.button :submit, 'Save' %>
+  <% end %>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -26,6 +26,7 @@
             <%= link_to "Home", root_path, class: "dropdown-item" %>
             <%= link_to "Friends", root_path, class: "dropdown-item" %>
             <%= link_to "New Happy Thing", new_happy_thing_path, class: "dropdown-item" %>
+            <%= link_to "Old Happy Thing", root_path, class: "dropdown-item" %>
             <%= link_to "My Account", edit_user_registration_path, class: "dropdown-item" %>
             <%# <li><a class="dropdown-item" href="#">Another action</a></li> %>
             <li><hr class="dropdown-divider"></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,18 +11,20 @@ Rails.application.routes.draw do
   end
 
   # If not authenticated, route to the home page
-  root to: "pages#home"
+  root to: 'pages#home'
 
+  # Happy Things
   get 'happy_things/:date', to: 'happy_things#show_by_date', as: :happy_things_by_date, constraints: { date: /\d{4}-\d{2}-\d{2}/ }
-  # get 'happy_things/:date', to: 'happy_things#show_by_date', as: :happy_things_by_date
-
+  get 'happy_things/old_happy_thing', to: 'happy_things#old_happy_thing', as: :old_happy_thing
+  post 'happy_things/old_happy_thing', to: 'happy_things#create_old_happy_thing'
   resources :happy_things
 
-
+  # Friendships
   resources :friendships do
     post :change_status, on: :member
   end
 
+  # Poems
   resources :dashboards, as: :dashboard do
     # get :retrieve_poem, on: :collection
   end


### PR DESCRIPTION
New feature allowing users to record Happy Things from past dates

- Added a new route, `happy_things/old_happy_thing`, for displaying the form to record a past Happy Thing
- Created new controller actions `old_happy_thing` and `create_old_happy_thing` in `HappyThingsController` to handle the new feature
- Updated the `HappyThing` model with a conditional callback to only set the current datetime if it's not already set
- Made minor styling adjustments to the alerts for a better user experience
- Adjusted form rendering to handle the new `start_time` field and ensure data integrity
- Included a link in the dashboard for users to navigate to the new form and record past Happy Things

<img width="706" alt="Screenshot 2023-10-04 at 13 44 47" src="https://github.com/emmvs/five_things/assets/90188399/18117474-00ab-493d-8f7c-16e07d3dc83e">
