### PR TITLE
Exclude Friends Already Connected in Users Index

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,7 +19,7 @@
 
   <h2 class="mt-3">Users</h2>
   <% @users.each do |user| %>
-    <% next if user == current_user %>
+    <% next if user == current_user || current_user.friends.include?(user) %>
     <% direct_friendship = current_user.friendships.find { |f| f.friend_id == user.id } %>
     <% inverse_friendship = user.friendships.find { |f| f.user_id == current_user.id } %>
 


### PR DESCRIPTION
- Refactored the Users Index page to exclude users who are already friends with the current user
- Updated the logic to skip displaying users who are friends or have pending friend requests
- Improved the user experience by preventing redundant friend requests to existing connections