### PR TITLE
Bugfix/emoji view on calendar

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -18,13 +18,15 @@ class DashboardsController < ApplicationController
   # Sets various collections of HappyThings based on user's friends & specific time periods
   def set_happy_things
     friend_ids = current_user.friends_and_inverse_friends_ids
-    @happy_things = HappyThing.where(user_id: friend_ids).order(created_at: :desc)
+    user_ids = friend_ids + [current_user.id]
+
+    @happy_things_of_you_and_friends = HappyThing.where(user_id: user_ids).order(created_at: :desc)
     fetch_periodic_happy_things(friend_ids)
   end
 
   # Fetch HappyThings f/ specific periods: today, last two days, and one year ago
   def fetch_periodic_happy_things(friend_ids)
-    friend_ids_with_self = friend_ids + [current_user.id]  # Ensure the current user's ID is also included
+    friend_ids_with_self = friend_ids + [current_user.id]
     @happy_things_today = happy_things_by_period(Date.today..Date.tomorrow, friend_ids_with_self)
     @happy_things_of_the_last_two_days = happy_things_by_period((Date.today - 1.days)..Date.today.end_of_day, friend_ids_with_self)
     @happy_things_one_year_ago = HappyThing.where('DATE(start_time) = ? AND user_id IN (?)', 1.year.ago.to_date, friend_ids_with_self).group_by(&:user)

--- a/app/models/happy_thing.rb
+++ b/app/models/happy_thing.rb
@@ -35,24 +35,25 @@ class HappyThing < ApplicationRecord
     self.start_time ||= Time.zone.now
   end
 
-  def ai_title
+  def ai_title # rubocop:disable Metrics/MethodLength
     Rails.cache.fetch("#{cache_key_with_version}/content") do
       client = OpenAI::Client.new
       chaptgpt_response = client.chat(
         parameters: {
-          model: "gpt-4",
+          model: 'gpt-4',
           messages: [{
-            role: "user",
+            role: 'user',
             content: "Give me a simple thing to do that would make someone happy who is suffering from depression. Give me only the title, without any of your own weird metaphors or answers like 'Here is a simple happy thing.' Please ensure that the things are unique and suitable for intelligent people who need their brains stimulated by good things. It should fit into a text like so: 'Something to make you happy is\n todo.'"}]
-        })
-      @ai_happy_thing = chaptgpt_response["choices"][0]["message"]["content"]
+        }
+      )
+      @ai_happy_thing = chaptgpt_response['choices'][0]['message']['content']
     end
   end
 
   private
 
   def set_default_category
-    self.category ||= Category.find_by(name: "General")
+    self.category ||= Category.find_by(name: 'General')
   end
 
   def start_time_present?
@@ -60,12 +61,11 @@ class HappyThing < ApplicationRecord
   end
 
   def check_happy_things_count
-    count_today = self.user.happy_things.where('created_at >= ?', Time.zone.now.beginning_of_day).count
+    count_today = user.happy_things.where('created_at >= ?', Time.zone.now.beginning_of_day).count
+    return unless count_today == 5
 
-    if count_today == 5
-      self.user.friends.each do |friend|
-        UserMailer.happy_things_notification(friend).deliver_now
-      end
+    user.friends.each do |friend|
+      UserMailer.happy_things_notification(friend).deliver_now
     end
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -5,7 +5,7 @@
 <div class="container mt-1">
   <div class="dash-box mx-2 my-3">
     <h2 class="dashboards_header">
-      <%= time_based_greeting %> <%= current_user ? current_user.first_name : "Sunshine" %>, and welcome to your Dashboard! <%= time_based_emoji %>
+      <%= time_based_greeting %> <%= current_user ? current_user.first_name : "Sunshine" %>! <%= time_based_emoji %>
     </h2>
       <div class="my-3">
         <h4>Happy Streak</h4>
@@ -32,7 +32,7 @@
 
   <!-- Section: Calendar -->
   <div id="calendar" class="mx-2 my-3">
-    <%= month_calendar(events: @happy_things, param_name: :date) do |date, happy_things_bubbles| %>
+    <%= month_calendar(events: @happy_things_of_you_and_friends, param_name: :date) do |date, happy_things_bubbles| %>
       <div class="day d-flex justify-content-center align-items-center">
         <% if happy_things_bubbles.any? %>
           <% unique_users = happy_things_bubbles.map(&:user).uniq %>


### PR DESCRIPTION
This PR fixes the Bug that, as a user, you were not able to see your own HappyThing `Emojis on the dashboard#index` calendar. I also refactored the `personal greeting` to the user and the `HappyThing Model`.