### PR TITLE
Feature/add google apple signin #125

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,10 @@ gem 'sassc-rails' # Use SCSS for stylesheets
 # Devise for authentication
 gem 'devise', '~> 4.8'
 
+#OAauth Providers
+gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
+
 # Pagination with kaminari
 gem 'kaminari'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -156,6 +157,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
+    jwt (3.0.0)
+      base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -173,6 +176,7 @@ GEM
       addressable (~> 2.8)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -211,6 +215,29 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.12)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (>= 1.1.8, < 3)
+    omniauth (2.1.3)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -231,6 +258,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.1.0)
@@ -356,6 +386,9 @@ GEM
     simple_form (5.3.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -376,6 +409,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    version_gem (1.1.8)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -396,6 +430,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
@@ -419,6 +454,8 @@ DEPENDENCIES
   kaminari
   letter_opener
   moonphases
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,2 @@
+class Users::OmniauthCallbacksController < ApplicationController
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
+# app/controllers/users/omniauth_callbacks_controller.rb
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    skip_before_action :authenticate_user!
   
     def google_oauth2
       user = User.from_omniauth(auth)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,33 +1,36 @@
-# app/controllers/users/omniauth_callbacks_controller.rb
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  
-    def google_oauth2
+  def google_oauth2
+    begin
       user = User.from_omniauth(auth)
-      user.save if user.new_record?
       
-      if user.present?
+      if user.persisted?
         sign_out_all_scopes
         flash[:success] = t 'devise.omniauth_callbacks.success', kind: 'Google'
         sign_in_and_redirect user, event: :authentication
       else
-        flash[:alert] = t 'devise.omniauth_callbacks.failure', kind: 'Google', reason: "#{auth.info.email} is not authorized."
+        flash[:alert] = 'Authentication failed. Please try again.'
         redirect_to new_user_session_path
       end
-    end
-  
-    protected
-  
-    def after_omniauth_failure_path_for(_scope)
-      new_user_session_path
-    end
-  
-    def after_sign_in_path_for(resource_or_scope)
-      stored_location_for(resource_or_scope) || root_path
-    end
-  
-    private
-  
-    def auth
-      @auth ||= request.env['omniauth.auth']
+    rescue => e
+      Rails.logger.error "OAuth failed: #{e.message}"
+      flash[:alert] = 'Authentication failed. Please try again.'
+      redirect_to new_user_session_path
     end
   end
+
+  protected
+
+  def after_omniauth_failure_path_for(_scope)
+    new_user_session_path
+  end
+
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || root_path
+  end
+
+  private
+
+  def auth
+    @auth ||= request.env['omniauth.auth']
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,2 +1,33 @@
-class Users::OmniauthCallbacksController < ApplicationController
-end
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    skip_before_action :authenticate_user!
+  
+    def google_oauth2
+      user = User.from_omniauth(auth)
+      user.save if user.new_record?
+      
+      if user.present?
+        sign_out_all_scopes
+        flash[:success] = t 'devise.omniauth_callbacks.success', kind: 'Google'
+        sign_in_and_redirect user, event: :authentication
+      else
+        flash[:alert] = t 'devise.omniauth_callbacks.failure', kind: 'Google', reason: "#{auth.info.email} is not authorized."
+        redirect_to new_user_session_path
+      end
+    end
+  
+    protected
+  
+    def after_omniauth_failure_path_for(_scope)
+      new_user_session_path
+    end
+  
+    def after_sign_in_path_for(resource_or_scope)
+      stored_location_for(resource_or_scope) || root_path
+    end
+  
+    private
+  
+    def auth
+      @auth ||= request.env['omniauth.auth']
+    end
+  end

--- a/app/helpers/users/omniauth_callbacks_helper.rb
+++ b/app/helpers/users/omniauth_callbacks_helper.rb
@@ -1,0 +1,2 @@
+module Users::OmniauthCallbacksHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,7 +105,7 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
-      user.first_name = auth.info.name || auth.info.name.split(' ').first.capitalize
+      user.first_name = auth.info.name || auth.info.email.split('@').first.capitalize
       user.password = generate_password_for_oauth
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,9 @@
 #  email_opt_in           :boolean          default(FALSE)
 #  location_opt_in        :boolean          default(FALSE)
 #  username               :string
-#
+#  provider               :string
+#  "uid"                  :string
+# 
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@
 #  location_opt_in        :boolean          default(FALSE)
 #  username               :string
 #  provider               :string
-#  "uid"                  :string
+#  uid                    :string
 # 
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-<%= link_to "Log in", new_session_path(resource_name), class: "btn btn-secondary btn-sm mt-1" %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: "btn btn-secondary btn-sm mt-1" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -17,7 +17,6 @@
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn' %><br />
 <% end %>
-
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_user_confirmation_path %><br />

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,14 +1,22 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "btn btn-secondary btn-sm mt-1" %><br />
+<%= link_to "Log in", new_session_path(resource_name), class: "btn btn-secondary btn-sm mt-1" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to "Sign up", new_registration_path(resource_name), class: "btn button--primary w-100 btn-secondary mt-1 d-block border-0" %><br />
 <% end %>
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= form_for "Login", url: omniauth_authorize_path(resource_name, provider), method: :post, data: {turbo: "false"} do |f| %>
+      <%= f.submit "Sign in with Google", class: "btn button--primary w-100 btn-secondary mt-1 d-block border-0" %>
+    <% end %>
+  <% end %>
+<% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn' %><br />
 <% end %>
+
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_user_confirmation_path %><br />
@@ -18,13 +26,3 @@
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= form_for "Login",
-      url: omniauth_authorize_path(resource_name, provider),
-      method: :post,
-      data: {turbo: "false"} do |f| %>
-        <%= f.submit "Login with Google", class: "btn btn-primary" %>
-    <% end %>  
-  <% end %>
-<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -5,6 +5,7 @@
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to "Sign up", new_registration_path(resource_name), class: "btn button--primary w-100 btn-secondary mt-1 d-block border-0" %><br />
 <% end %>
+
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= form_for "Login", url: omniauth_authorize_path(resource_name, provider), method: :post, data: {turbo: "false"} do |f| %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,11 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= form_for "Login",
+      url: omniauth_authorize_path(resource_name, provider),
+      method: :post,
+      data: {turbo: "false"} do |f| %>
+        <%= f.submit "Login with Google", class: "btn btn-primary" %>
+    <% end %>  
   <% end %>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -309,4 +309,6 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  config.omniauth :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
   root to: 'pages#home'
 
   # Users
-  devise_for :users
+  devise_for :users,
+    controllers: {
+      omniauth_callbacks: 'users/omniauth_callbacks'
+    }
   resources :users, only: %i[index show]
 
   # Happy Things

--- a/db/migrate/20250618210827_add_omniauth_to_users.rb
+++ b/db/migrate/20250618210827_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_20_155126) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_18_210827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_20_155126) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "provider"
+    t.string "uid"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,5 +80,14 @@ RSpec.describe User, type: :model do # rubocop:disable Metrics/BlockLength
         User.from_omniauth(auth_hash)
       }.to change(User, :count).by(1)
     end
+
+    it 'finds existing user with same provider and uid' do
+      existing_user = create(:user, provider: 'google_oauth2', uid: '123456789', email: 'emmazing@gmail.com')
+
+      user = User.from_omniauth(auth_hash)
+
+      expect(user).to eq(existing_user)
+      expect(User.count).to eq(1)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,33 +105,41 @@ RSpec.describe User, type: :model do # rubocop:disable Metrics/BlockLength
 
     context 'when confirmed manual user tries OAuth' do
       it 'links OAuth to existing confirmed account' do
-        existing_user = create(:user, email: auth_hash.info.email, confirmed_at: 1.day.ago)
+        existing_user = create(:user, 
+          email: auth_hash.info.email, 
+          confirmed_at: 1.day.ago)
         
         user = User.from_omniauth(auth_hash)
+        existing_user.reload
         
         expect(user).to eq(existing_user)
-        expect(user.provider).to eq('google_oauth2')
-        expect(user.uid).to eq('123456789')
+        expect(existing_user.provider).to eq('google_oauth2')
+        expect(existing_user.uid).to eq('123456789')
         expect(User.count).to eq(1)
       end
     end
 
     context 'when unconfirmed manual user tries OAuth' do
       it 'links OAuth and auto-confirms existing account' do
-        existing_user = create(:user, email: auth_hash.info.email, confirmed_at: nil)
+        existing_user = create(:user, 
+          email: auth_hash.info.email, 
+          confirmed_at: nil)
         
         user = User.from_omniauth(auth_hash)
+        existing_user.reload
         
         expect(user).to eq(existing_user)
-        expect(user.provider).to eq('google_oauth2')
-        expect(user.confirmed?).to be true
+        expect(existing_user.provider).to eq('google_oauth2')
+        expect(existing_user.uid).to eq('123456789')
+        expect(existing_user.confirmed?).to be true
         expect(User.count).to eq(1)
       end
     end
 
     context 'when OAuth user has different email' do
       it 'creates separate user for different email' do
-        create(:user, email: 'wonky@example.com')
+        create(:user, 
+          email: 'different@email.com')
         
         expect {
           User.from_omniauth(auth_hash)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe User, type: :model do # rubocop:disable Metrics/BlockLength
         provider: 'google_oauth2',
         uid: '123456789',
         info: {
-          name: 'Emma Doe',
+          name: 'Emma Who',
           email: 'emmazing@gmail.com'
         }
       })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,4 +62,23 @@ RSpec.describe User, type: :model do # rubocop:disable Metrics/BlockLength
       end
     end
   end
+
+  describe '.from_omniauth' do
+    let(:auth_hash) do
+      OmniAuth::AuthHash.new({
+        provider: 'google_oauth2',
+        uid: '123456789',
+        info: {
+          name: 'Emma Doe',
+          email: 'emmazing@gmail.com'
+        }
+      })
+    end
+
+    it 'creates a new user from Google OAuth' do
+      expect {
+        User.from_omniauth(auth_hash)
+      }.to change(User, :count).by(1)
+    end
+  end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+    config.before(:each, type: :feature) do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+            provider: 'google_oauth2',
+            uid: '123456789',
+            info: {
+                name: 'Emma Doe',
+                email: 'emmazing@gmail.com'
+            }
+        })
+    end
+
+    config.after(:each, type: :feature) do
+        OmniAuth.config.mock_auth[:google_oauth2] = nil
+    end
+end


### PR DESCRIPTION
This PR implements Google OAuth sign-in with account linking for existing users. 🙂
Apple sign-in was excluded. 😔

Production setup:
Set env vars

> GOOGLE_OAUTH_CLIENT_ID

> GOOGLE_OAUTH_CLIENT_SECRET

Testing: Unit tests use mocked OAuth. Manual testing requires real Google credentials (env vars + Console setup with localhost callback).

#125