### PR TITLE
Feature/email opt out

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux

--- a/app/models/happy_thing.rb
+++ b/app/models/happy_thing.rb
@@ -84,7 +84,7 @@ class HappyThing < ApplicationRecord
   end
 
   def notify_friends_about_happy_things
-    user.friends_and_friends_who_added_me.each do |friend|
+    user.friends_and_friends_who_added_me.where(email_opt_in: true).each do |friend|
       UserMailer.happy_things_notification(friend).deliver_later
     end
   end

--- a/app/models/happy_thing.rb
+++ b/app/models/happy_thing.rb
@@ -80,7 +80,10 @@ class HappyThing < ApplicationRecord
     today_count = user.happy_things.where(start_time: Time.zone.today.all_day).count
     return unless today_count == 5
 
+    return if user.daily_happy_email_sent
+
     notify_friends_about_happy_things
+    user.update(daily_happy_email_sent: true)
   end
 
   def notify_friends_about_happy_things

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -27,6 +27,8 @@
                   input_html: { autocomplete: "new-password" } %>
       <%= f.input :emoji %>
       <%= f.input :email, required: true, autofocus: true %>
+      <%= f.input :email_opt_in, as: :boolean, required: false,
+                  label: 'I agree to receive emails about my happy things and other updates.' %>
       <%= f.input :password,
                   hint: "leave it blank if you don't want to change it",
                   required: false,

--- a/db/migrate/20250701092434_add_daily_happy_email_sent_to_users.rb
+++ b/db/migrate/20250701092434_add_daily_happy_email_sent_to_users.rb
@@ -1,0 +1,5 @@
+class AddDailyHappyEmailSentToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :daily_happy_email_sent, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_20_155126) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_01_092434) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_20_155126) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.boolean "daily_happy_email_sent", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/happy_thing_spec.rb
+++ b/spec/models/happy_thing_spec.rb
@@ -38,14 +38,20 @@ RSpec.describe HappyThing, type: :model do # rubocop:disable Metrics/BlockLength
   end
 
   describe 'Callbacks' do
+    let(:user) { create(:user) }
+    before { ActionMailer::Base.deliveries.clear }
+
+    def create_bi_directional_friendship(user, friend)
+      create(:friendship, user:, friend:)
+      create(:friendship, user: friend, friend: user)
+    end
+
     context 'when a user adds 5 happy things in a day' do
-      it 'sends an email to each of their friends' do
-        user = create(:user)
-        friends = create_list(:user, 3)
+      it 'sends an email to each of their friends that opted-in to receiving emails' do
+        friends = create_list(:user, 3, email_opt_in: true)
 
         friends.each do |friend|
-          create(:friendship, user:, friend:)
-          create(:friendship, user: friend, friend: user)
+          create_bi_directional_friendship(user, friend)
         end
 
         perform_enqueued_jobs do
@@ -58,37 +64,61 @@ RSpec.describe HappyThing, type: :model do # rubocop:disable Metrics/BlockLength
           expect(delivered_emails).to include(friend.email)
         end
       end
-    end
-  end
 
-  describe 'Mailers' do
-    before { clear_enqueued_jobs }
+      it 'sends no email to their friends that opted-out of receiving emails' do
+        opted_in_friend = create(:user, email_opt_in: true)
+        create_bi_directional_friendship(user, opted_in_friend)
 
-    it 'sends an email to each of their friends but not to non-friends' do
-      user = create(:user)
-      friends = create_list(:user, 3)
-      non_friend = create(:user)
+        opted_out_friend = create(:user, email_opt_in: false)
+        create_bi_directional_friendship(user, opted_out_friend)
 
-      friends.each do |friend|
-        create(:friendship, user:, friend:)
-        create(:friendship, user: friend, friend: user)
+        perform_enqueued_jobs do
+          create_list(:happy_thing, 5, user:)
+        end
+
+        delivered_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+
+        expect(delivered_emails).to include(opted_in_friend.email)
+        expect(delivered_emails).not_to include(opted_out_friend.email)
       end
 
-      create_list(:happy_thing, 4, user:)
+      it 'sends an email to their friends but not to non-friends' do
+        friend = create(:user, email_opt_in: true)
+        non_friend = create(:user, email_opt_in: true)
+        create_bi_directional_friendship(user, friend)
 
-      perform_enqueued_jobs do
-        create(:happy_thing, user:)
-      end
+        perform_enqueued_jobs do
+          create_list(:happy_thing, 5, user:)
+        end
 
-      delivered_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+        delivered_emails = ActionMailer::Base.deliveries.map(&:to).flatten
 
-      friends.each do |friend|
         expect(delivered_emails).to include(friend.email)
+        expect(delivered_emails).not_to include(non_friend.email)
       end
 
-      expect(delivered_emails).not_to include(non_friend.email)
+      it 'sends no email if user has no friends' do
+        create_list(:happy_thing, 5, user:)
+  
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+  
+      it 'only sends one email if happy thing #5 is deleted and recreated' do
+        friend = create(:user, email_opt_in: true)
+        create_bi_directional_friendship(user, friend)
+      
+        perform_enqueued_jobs do
+          create_list(:happy_thing, 5, user:)
+        end
+      
+        user.happy_things.last.destroy
+      
+        perform_enqueued_jobs do
+          create(:happy_thing, user:)
+        end
+      
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
     end
-
-    after { clear_performed_jobs }
   end
 end


### PR DESCRIPTION
This PR:
- adds email-preference field to account settings to let users opt-out of receiving happiness email notifcations
- makes the notification logic respect the users email-preferences

Notes:
- account settings page looks worse after this; but needs love anyway ❤️‍🩹
- probable bug in production: mailer sends 5 mails instead of 1 to inform friends of excess happiness