### PR TITLE
Fix user authentication enforcement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@
 class ApplicationController < ActionController::Base
   before_action :set_should_render_navbar
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!, unless: :public_controller?
 
   protected
 
@@ -16,5 +17,9 @@ class ApplicationController < ActionController::Base
 
   def set_should_render_navbar
     @should_render_navbar = false
+  end
+
+  def public_controller?
+    controller_name.in?(%w[pages])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_happy_thing
 
   def create

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,7 +2,6 @@
 
 # Controller for dashboard functionalities including fetching & displaying HappyThings
 class DashboardsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_happy_things
   before_action :set_happy_things_of_today, only: [:index]
 


### PR DESCRIPTION
This PR:
- fixes the previously spotty Devise user authentication
- moves authenticate_user! to ApplicationController and exempts the public PagesController

#141 