### PR TITLE
Fix/calender view emoji layout

### DIFF
--- a/app/assets/stylesheets/components/_calendar.scss
+++ b/app/assets/stylesheets/components/_calendar.scss
@@ -30,7 +30,6 @@
     padding: 1px;
     position: relative;
     height: 40px !important;
-    width: 40px !important;
     border-radius: $border-radius !important;
   }
 
@@ -38,6 +37,11 @@
     display: block;
     text-decoration: none;
     color: darken($soft-purple, 50%);
+  }
+
+  .day.has-many-emojis .calendar-day-link {
+    z-index: 1;
+    font-weight: calc(var(--bs-body-font-weight) * 1.1);
   }
 
   .calendar-day-link:hover {
@@ -65,11 +69,15 @@
     --bs-table-bg-type: none;
   }
 
-  .event-indicator {
+  .emoji-grid {
+    display: grid;
+    aspect-ratio: 1 / 1;
     position: absolute;
-    z-index: 1;
-    right: -5px;
-    top: -4px;
-    font-size: 1.1em;
+    pointer-events: none;
+  }
+
+  .emoji {
+    position: relative;
+    line-height: 1;
   }
 }

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -43,9 +43,9 @@ class DashboardsController < ApplicationController
 
   def set_happy_things
     friend_ids = current_user.friends_and_friends_who_added_me_ids
-    user_ids = friend_ids + [current_user.id]
+    @user_ids = [current_user.id] + friend_ids
 
-    @happy_things_of_you_and_friends = HappyThing.where(user_id: user_ids).order(created_at: :desc)
+    @happy_things_of_you_and_friends = HappyThing.where(user_id: @user_ids).order(created_at: :desc)
     fetch_happy_things_by_time(friend_ids)
   end
 

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -67,4 +67,35 @@ module DashboardHelper
       full_moon: '🌕'
     }
   end
+
+  # Calender
+  def calculate_grid_size(number_of_emojis)
+    return 2 if number_of_emojis == 1
+
+    Math.sqrt(number_of_emojis).ceil
+  end
+
+  def calculate_emoji_size(number_of_emojis)
+    grid_size = calculate_grid_size(number_of_emojis)
+    case grid_size
+    when 2 then 1.1
+    when 3 then 0.8
+    when 4 then 0.5
+    else
+      raise "Failure in calculate_emoji_size: number_of_emojis = #{number_of_emojis}, grid_size = #{grid_size}"
+    end
+  end
+
+  def calculate_emoji_position(tile_number, number_of_emojis)
+    return '0px, 0px' if number_of_emojis > 4
+
+    case tile_number
+    when 1 then '-4px, -5px'
+    when 2 then '4px, -5px'
+    when 3 then '-4px, 5px'
+    when 4 then '4px, 5px'
+    else
+      raise "Failure in calculate_emoji_position: number_of_emojis = #{number_of_emojis}, tile_number = #{tile_number}"
+    end
+  end
 end

--- a/app/views/dashboards/_calendar.html.erb
+++ b/app/views/dashboards/_calendar.html.erb
@@ -1,0 +1,17 @@
+<div class="d-flex justify-content-center align-items-center">
+  <div id="calendar" class="mb-2 my-3">
+    <%= month_calendar(events: @happy_things_of_you_and_friends, param_name: :date) do |date, happy_things_bubbles| %>
+      <div class="day d-flex justify-content-center align-items-center">
+        <% if happy_things_bubbles.any? %>
+          <% unique_users = happy_things_bubbles.map(&:user).uniq %>
+          <% unique_users.each do |user| %>
+            <div class="event-indicator"><%= user.emoji %></div>
+          <% end %>
+        <% end %>
+        <%= link_to happy_things_by_date_path(date: date.strftime('%Y-%m-%d')), class: 'calendar-day-link' do %>
+          <%= date.day %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboards/_calendar.html.erb
+++ b/app/views/dashboards/_calendar.html.erb
@@ -1,13 +1,28 @@
 <div class="d-flex justify-content-center align-items-center">
   <div id="calendar" class="mb-2 my-3">
     <%= month_calendar(events: @happy_things_of_you_and_friends, param_name: :date) do |date, happy_things_bubbles| %>
-      <div class="day d-flex justify-content-center align-items-center">
+      <% unique_users = happy_things_bubbles.map(&:user).uniq %>
+      <% unique_users_sorted = unique_users.sort_by { |user| @user_ids.index(user.id) } %>
+      <% number_of_emojis = unique_users.length %>
+      <div class="day d-flex justify-content-center align-items-center <%= 'has-many-emojis' if number_of_emojis > 4 %>">
         <% if happy_things_bubbles.any? %>
-          <% unique_users = happy_things_bubbles.map(&:user).uniq %>
-          <% unique_users_sorted = unique_users.sort_by { |user| @user_ids.index(user.id) } %>
-          <% unique_users_sorted.each do |user| %>
-            <div class="event-indicator"><%= user.emoji %></div>
-          <% end %>
+          <div 
+            class="emoji-grid"
+            style="
+                grid-template-columns: repeat(<%= calculate_grid_size(number_of_emojis) %>, 1fr);
+                grid-template-rows: repeat(<%= calculate_grid_size(number_of_emojis) %>, 1fr);
+            ">
+            <% unique_users_sorted.each_with_index do |user, index| %>
+              <div 
+                class="emoji" 
+                style="
+                    font-size: <%= calculate_emoji_size(number_of_emojis) %>em;
+                    transform: translate(<%= calculate_emoji_position(index + 1, number_of_emojis) %>);
+              ">
+                <%= user.emoji %>
+            </div>
+            <% end %>
+          </div>
         <% end %>
         <%= link_to happy_things_by_date_path(date: date.strftime('%Y-%m-%d')), class: 'calendar-day-link' do %>
           <%= date.day %>

--- a/app/views/dashboards/_calendar.html.erb
+++ b/app/views/dashboards/_calendar.html.erb
@@ -4,7 +4,8 @@
       <div class="day d-flex justify-content-center align-items-center">
         <% if happy_things_bubbles.any? %>
           <% unique_users = happy_things_bubbles.map(&:user).uniq %>
-          <% unique_users.each do |user| %>
+          <% unique_users_sorted = unique_users.sort_by { |user| @user_ids.index(user.id) } %>
+          <% unique_users_sorted.each do |user| %>
             <div class="event-indicator"><%= user.emoji %></div>
           <% end %>
         <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -32,23 +32,7 @@
   </div>
 
   <!-- Section: Calendar -->
-  <div class="d-flex justify-content-center align-items-center">
-    <div id="calendar" class="mb-2 my-3">
-      <%= month_calendar(events: @happy_things_of_you_and_friends, param_name: :date) do |date, happy_things_bubbles| %>
-        <div class="day d-flex justify-content-center align-items-center">
-          <% if happy_things_bubbles.any? %>
-            <% unique_users = happy_things_bubbles.map(&:user).uniq %>
-            <% unique_users.each do |user| %>
-              <div class="event-indicator"><%= user.emoji %></div>
-            <% end %>
-          <% end %>
-          <%= link_to happy_things_by_date_path(date: date.strftime('%Y-%m-%d')), class: 'calendar-day-link' do %>
-            <%= date.day %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <%= render 'calendar' %>
 
   <!-- Section: HappyThings List -->
   <div data-controller="insert-in-list">


### PR DESCRIPTION
This PR adds a grid layout (and helpers to calculate styling variables) to the calendar display (extracted to a partial) on the dashboard page to space out the emojis of different users.

For >4 emojis it still looks quite bad - left it for now, till we figure out the final design for the calendar.

#107 