### PR TITLE
Fix dashboard greetings and tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,22 @@
-# Five Things App
+# Five Things
 
-## Overview
+A Rails app for noticing the small joys in life — log what made you happy, share with friends, and build a streak of good days.
 
-The 5 Things App is designed to help users appreciate the smaller joys in life by listing down five things that make them happy every day.
+## Documentation
 
-## Getting Started
+### 🛠️ Development
 
-These instructions will get you a copy of the project up and running on your local machine
+- [Getting started](docs/getting_started.md) — Prerequisites, install, database, dev server, tests, and linting
+- [Deployment](docs/deployment.md)
+- [AGENTS.md](AGENTS.md) — Coding standards for AI assistants (security, RuboCop, i18n, testing)
+- [CI workflow](.github/workflows/ci.yml) — RuboCop and Brakeman on push/PR to `main`
 
-### Prerequisites & System Dependencies
+#### AI agent config
 
-Ensure that you have the following installed on your local machine:
+- [`.cursor/rules/rails-standards.mdc`](.cursor/rules/rails-standards.mdc) — Cursor rules (always applied)
+- [AGENTS.md](AGENTS.md) — GitHub Copilot / agent instructions
 
-* [Ruby](https://www.ruby-lang.org/en/documentation/installation/) - 3.4.4
-* [Rails](https://guides.rubyonrails.org/v5.0/getting_started.html) - 8.0.3
-* PostgreSQL
-
-### Installation
-
-1. Clone the repository to your local machine
-   
-`git clone https://github.com/yourusername/five-things.git`
-
-2. Navigate to the project directory
-
-`cd five-things`
-
-3. Install necessary gems
-
-`bundle install`
-
-4. Install PostgreSQL
-
-```
-brew install postgresql
-brew services start postgresql
-```
-
-### Database Creation
-
-1. Create the database
-
-`rails db:create`
-
-3. Migrate the database
-
-`rails db:migrate`
-
-### Database Initialization
-
-1. Seed the database
-
-`rails db:seed`
-
-### Running Tests
-
-1. To run the complete test suite, execute
-
-```bash
-rspec # run all tests
-rspec spec/requests/users_spec.rb # run a specific test
-```
-
-### Development Server
-
-**Option 1: Using Foreman (recommended for production-like environment)**
-
-Start both Rails server and ngrok simultaneously:
-
-```bash
-bin/dev
-```
-
-This will start:
-- Rails server on `http://localhost:3000`
-- ngrok tunnel (URL will be shown in the logs)
-
-**Option 2: Manual setup (recommended for debugging with binding.pry)**
-
-Start Rails server and ngrok separately:
-
-**Terminal 1 - Rails Server:**
-```bash
-rails s
-```
-
-**Terminal 2 - ngrok (for mobile testing):**
-```bash
-ngrok http 3000
-```
-
-The ngrok URL will be displayed in Terminal 2 under "Forwarding" (e.g., `https://abc123.ngrok-free.app`, `https://abc123.ngrok-free.dev`, or `https://abc123.ngrok.io`). Use this URL to test the app on your mobile device. Ngrok URLs may end in `.app`, `.dev`, or `.io` depending on your ngrok account. The app is configured to accept all formats. 🙌🏻
-
-### Linting
-
-RuboCop is configured via `.rubocop.yml`. Run it locally with:
-
-```bash
-bundle exec rubocop
-```
-
-The CI pipeline also runs RuboCop and Brakeman automatically on every push and PR to `main` (see `.github/workflows/ci.yml`).
-
-### AI Agent Configuration
-
-This project includes configuration files that provide coding standards to AI assistants:
-
-- **`.cursor/rules/rails-standards.mdc`** — rules for Cursor (always applied)
-- **`AGENTS.md`** — rules for GitHub Copilot
-
-Both files enforce the same standards: security (never commit secrets), RuboCop compliance, DRY principles, and i18n translations across all three locale files (`en.yml`, `de.yml`, `sv.yml`).
-
-### Security
-
-Secrets and credentials must **never** be committed to this repository. The `.gitignore` is configured to exclude `.env*` files (except the empty `.env.sample`), `config/master.key`, and `cloudinary.yml`. If you need to add a new environment variable:
-
-1. Add the key (with an empty value) to `.env.sample` so other developers know it exists.
-2. Set the actual value in your local `.env` file (which is git-ignored).
-3. In code, access it via `ENV.fetch("VAR_NAME")` or Rails credentials.
-
-Brakeman runs in CI to catch common security vulnerabilities. Run it locally with:
-
-```bash
-bundle exec brakeman -q -w2
-```
-
-### Services
-
-- Poetry Service: Fetches a random poem to display on the page.
-
-### Deployment Instructions
-
-1. Precompile assets
-
-`rails assets:precompile`
-
-3. Push to your deployment platform
+Both enforce the same standards: never commit secrets, RuboCop compliance, DRY, and i18n across `en.yml`, `de.yml`, and `sv.yml`.
 
 ## Contributing
 
@@ -143,9 +24,7 @@ If you would like to contribute, please fork the repository and use a feature br
 
 ## Contact
 
-- Repository: [Five Things App](https://github.com/emmvs/five_things)
-- Developer: Emma Rünzel - emma@ruenzel.de
-
-**Enjoy Five Things, and remember to appreciate the litte things!**
+- Repository: [emmvs/five_things](https://github.com/emmvs/five_things)
+- Emma Rünzel — [emma@ruenzel.de](mailto:emma@ruenzel.de)
 
 Made with ♥️ by emmvs

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,3 +1,6 @@
+$homepage-padding-x: 1.25rem;
+$homepage-padding-y: 2rem;
+
 .homepage-container {
   display: flex;
   flex-direction: column;
@@ -5,7 +8,11 @@
   justify-content: center;
   min-height: 100vh;
   min-height: 100dvh;
-  padding: 2rem 1rem;
+  padding: $homepage-padding-y $homepage-padding-x;
+  padding-top: unquote("max(#{$homepage-padding-y}, env(safe-area-inset-top, 0px))");
+  padding-right: unquote("max(#{$homepage-padding-x}, env(safe-area-inset-right, 0px))");
+  padding-bottom: unquote("max(#{$homepage-padding-y}, env(safe-area-inset-bottom, 0px))");
+  padding-left: unquote("max(#{$homepage-padding-x}, env(safe-area-inset-left, 0px))");
   background: $off-white;
 }
 
@@ -70,6 +77,20 @@
 
   &:active {
     transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba($soft-purple, 0.55);
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover,
+    &:active {
+      transform: none;
+    }
   }
 
   &--primary {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -8,11 +8,10 @@ $homepage-padding-y: 2rem;
   justify-content: center;
   min-height: 100vh;
   min-height: 100dvh;
-  padding: $homepage-padding-y $homepage-padding-x;
-  padding-top: unquote("max(#{$homepage-padding-y}, env(safe-area-inset-top, 0px))");
-  padding-right: unquote("max(#{$homepage-padding-x}, env(safe-area-inset-right, 0px))");
-  padding-bottom: unquote("max(#{$homepage-padding-y}, env(safe-area-inset-bottom, 0px))");
-  padding-left: unquote("max(#{$homepage-padding-x}, env(safe-area-inset-left, 0px))");
+  padding-top: calc(#{$homepage-padding-y} + env(safe-area-inset-top, 0px));
+  padding-right: calc(#{$homepage-padding-x} + env(safe-area-inset-right, 0px));
+  padding-bottom: calc(#{$homepage-padding-y} + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(#{$homepage-padding-x} + env(safe-area-inset-left, 0px));
   background: $off-white;
 }
 

--- a/app/assets/stylesheets/pages/_login.scss
+++ b/app/assets/stylesheets/pages/_login.scss
@@ -1,31 +1,90 @@
-.login-page {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh;
-  min-height: 100dvh;
-  padding: 2rem 1rem;
+// Login shares homepage-container / homepage-title / homepage-btn with the landing page.
+// Keeps 44px touch targets, focus-visible, and reduced motion.
+$login-touch-min: 44px;
 
-  &__content {
-    width: 100%;
-    max-width: 380px;
-    text-align: center;
+.login-page {
+  &__headline {
+    margin-bottom: 2.5rem;
+    // Shorter than homepage hero gap (4rem); form adds vertical weight. Responsive size for long i18n lines.
+    font-size: 2rem !important;
+    line-height: 1.2;
+
+    @media (min-width: 24rem) {
+      font-size: 2.5rem !important;
+    }
+
+    @media (min-width: 36rem) {
+      font-size: 3rem !important;
+    }
   }
 
-  &__title {
-    font-family: $accent-font;
-    font-weight: 300;
-    font-size: 1.5rem;
+  &__form {
+    width: 100%;
+    max-width: 22rem;
+    margin: 0 auto;
+
+    .string {
+      margin-bottom: 1rem;
+    }
+  }
+
+  &__input {
+    width: 100%;
+    min-height: $login-touch-min;
+    padding: 0.75rem 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    border-radius: 50px;
+    font-family: $body-font;
+    font-size: 1rem;
+    font-weight: 400;
     color: $color-text-body;
-    margin-bottom: 2rem;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow:
+      0 2px 12px rgba(0, 0, 0, 0.06),
+      inset 0 1px 1px rgba(255, 255, 255, 0.8),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.03);
+    transition: box-shadow 0.2s ease, background 0.2s ease;
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      background: rgba(255, 255, 255, 0.75);
+      box-shadow:
+        0 2px 12px rgba(0, 0, 0, 0.06),
+        inset 0 1px 1px rgba(255, 255, 255, 0.9),
+        0 0 0 3px rgba($soft-purple, 0.2);
+      outline: 2px solid rgba($soft-purple, 0.55);
+      outline-offset: 2px;
+    }
+
+    &::placeholder {
+      color: $light-gray;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  &__submit {
+    width: 100%;
+    min-height: $login-touch-min;
+    margin-top: 0.25rem;
+    box-sizing: border-box;
   }
 
   &__divider {
     display: flex;
     align-items: center;
     gap: 1rem;
-    margin: 1.5rem 0;
+    max-width: 22rem;
+    margin: 1.5rem auto;
     color: $light-gray;
+    font-family: $body-font;
     font-size: $font-size-s;
 
     &::before,
@@ -45,95 +104,48 @@
   &__footer {
     margin-top: 2rem;
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
-    gap: 1.5rem;
+    align-items: center;
+    gap: 0.5rem 1.5rem;
+    font-family: $body-font;
     font-size: $font-size-s;
-
-    a {
-      color: $gray;
-      text-decoration: none;
-      transition: color 0.2s ease;
-
-      &:hover {
-        color: darken($soft-purple, 15%);
-      }
-    }
-  }
-}
-
-.login-card {
-  background: rgba(255, 255, 255, 0.55);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.7);
-  border-radius: 20px;
-  padding: 2rem 1.5rem;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04);
-
-  .string {
-    margin-bottom: 0.75rem;
   }
 
-  &__input {
-    width: 100%;
-    padding: 14px 18px;
-    border: none;
-    border-radius: 14px;
-    font-size: 1rem;
-    background: rgba(255, 255, 255, 0.7);
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.04);
-    transition: box-shadow 0.2s ease, background 0.2s ease;
-
-    &:focus {
-      outline: none;
-      background: rgba(255, 255, 255, 0.9);
-      box-shadow: 0 0 0 3px rgba($soft-purple, 0.15);
-    }
-
-    &::placeholder {
-      color: $light-gray;
-    }
-  }
-
-  &__btn {
-    width: 100%;
-    margin-top: 0.5rem;
-    padding: 14px 24px;
-    border: 1px solid rgba(255, 255, 255, 0.6);
+  &__footer-link {
+    color: $gray;
+    text-decoration: none;
+    transition: color 0.2s ease;
+    min-height: $login-touch-min;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.25rem;
     border-radius: 50px;
-    font-size: 1rem;
-    font-weight: 500;
-    color: $color-text-body;
-    background: rgba(255, 255, 255, 0.45);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    box-shadow:
-      0 2px 12px rgba(0, 0, 0, 0.06),
-      inset 0 1px 1px rgba(255, 255, 255, 0.8),
-      inset 0 -1px 1px rgba(0, 0, 0, 0.03);
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    border: 1px solid transparent;
 
     &:hover {
-      transform: translateY(-1px);
-      background: rgba(255, 255, 255, 0.6);
-      box-shadow:
-        0 4px 18px rgba(0, 0, 0, 0.08),
-        inset 0 1px 1px rgba(255, 255, 255, 0.9),
-        inset 0 -1px 1px rgba(0, 0, 0, 0.03);
+      color: $color-text-body;
+      background: rgba(255, 255, 255, 0.3);
+      border-color: rgba(0, 0, 0, 0.06);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
     }
 
-    &:active {
-      transform: translateY(0);
-      background: rgba(255, 255, 255, 0.55);
+    &:focus-visible {
+      outline: 2px solid rgba($soft-purple, 0.55);
+      outline-offset: 3px;
     }
 
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 }
 
 .login-google-btn {
   width: 48px;
   height: 48px;
+  min-width: $login-touch-min;
+  min-height: $login-touch-min;
   border-radius: 50%;
   border: 1px solid #dadce0;
   background: $white;
@@ -151,5 +163,14 @@
 
   &:active {
     background: #f1f3f4;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba($soft-purple, 0.55);
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def login_wave_emoji
+    %w[👋🏻 👋🏼 👋🏽 👋🏾 👋🏿].sample
+  end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -4,7 +4,7 @@
 module DashboardHelper
   def time_based_greeting(first_name, timezone = nil)
     key = greeting_key_for_hour(current_hour_in(timezone))
-    t("dashboard.greetings.#{key}", name: first_name)
+    t("dashboard.greetings.#{key}", name: sanitized_greeting_name(first_name))
   end
 
   def time_based_emoji(timezone = nil) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
@@ -28,6 +28,10 @@ module DashboardHelper
   end
 
   private
+
+  def sanitized_greeting_name(name)
+    name.to_s.strip.sub(/\A,+\s*/, '').sub(/\s*,+\z/, '').strip
+  end
 
   def current_hour_in(timezone)
     tz = timezone || current_user&.timezone || 'UTC'

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -4,7 +4,7 @@
 module DashboardHelper
   def time_based_greeting(first_name, timezone = nil)
     key = greeting_key_for_hour(current_hour_in(timezone))
-    t("dashboard.greetings.#{key}", name: sanitized_greeting_name(first_name))
+    t("dashboard.greetings.#{key}", name: greeting_display_name(first_name))
   end
 
   def time_based_emoji(timezone = nil) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
@@ -29,8 +29,9 @@ module DashboardHelper
 
   private
 
-  def sanitized_greeting_name(name)
-    name.to_s.strip.sub(/\A,+\s*/, '').sub(/\s*,+\z/, '').strip
+  def greeting_display_name(name)
+    display_name = User.sanitize_display_name(name)
+    display_name.presence || t('dashboard.greetings.default_name')
   end
 
   def current_hour_in(timezone)

--- a/app/models/happy_thing.rb
+++ b/app/models/happy_thing.rb
@@ -79,14 +79,16 @@ class HappyThing < ApplicationRecord
   def check_happy_things_count
     today_count = user.happy_things.where(start_time: Time.zone.today.all_day).count
     return unless today_count == 5
+    return if user.friends_notified_today?
 
     notify_friends_about_happy_things
   end
 
   def notify_friends_about_happy_things
-    user.all_friends.each do |friend|
+    user.friends_with_email_opt_in.find_each do |friend|
       UserMailer.happy_things_notification(friend).deliver_later
     end
+    user.mark_friends_notified_today!
   end
 
   def geocoding_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,10 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # Friendships - Bidirectional: each friendship exists as two records
   has_many :friendships, dependent: :destroy
   has_many :friends, -> { where(friendships: { accepted: true }) }, through: :friendships, source: :friend
+  has_many :friends_with_email_opt_in,
+           -> { where(friendships: { accepted: true }, email_opt_in: true) },
+           through: :friendships,
+           source: :friend
   has_many :pending_friends, -> { where(friendships: { accepted: false }) }, through: :friendships, source: :friend
 
   def self.search(query)
@@ -95,6 +99,14 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # Aliases for backward compatibility
   alias friends_and_friends_who_added_me_ids friend_ids
   alias all_friends friends
+
+  def friends_notified_today?
+    notified_friends_on == Time.zone.today
+  end
+
+  def mark_friends_notified_today!
+    update_column(:notified_friends_on, Time.zone.today)
+  end
 
   def happy_streak
     return 0 if happy_things.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,11 +171,19 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     streak
   end
 
+  def self.sanitize_display_name(name)
+    cleaned = name.to_s.strip
+    while cleaned.match?(/\A[,\s]|[,\s]\z/)
+      cleaned = cleaned.gsub(/\A[,\s]+/, '').gsub(/[,\s]+\z/, '').strip
+    end
+    cleaned
+  end
+
   def self.generate_name_candidates(name_param, email) # rubocop:disable Metrics/CyclomaticComplexity
     [
-      name_param&.split&.first,
-      name_param&.strip,
-      email&.split('@')&.first&.split('.')&.first&.capitalize
+      sanitize_display_name(name_param&.split&.first),
+      sanitize_display_name(name_param),
+      sanitize_display_name(email&.split('@')&.first&.split('.')&.first&.capitalize)
     ]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,12 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     'User'
   end
 
+  def self.sanitize_display_name(name)
+    cleaned = name.to_s.strip
+    cleaned = cleaned.gsub(/\A[,\s]+/, '').gsub(/[,\s]+\z/, '').strip while cleaned.match?(/\A[,\s]|[,\s]\z/)
+    cleaned
+  end
+
   private
 
   def happy_things_dates
@@ -169,14 +175,6 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
       streak += 1
     end
     streak
-  end
-
-  def self.sanitize_display_name(name)
-    cleaned = name.to_s.strip
-    while cleaned.match?(/\A[,\s]|[,\s]\z/)
-      cleaned = cleaned.gsub(/\A[,\s]+/, '').gsub(/[,\s]+\z/, '').strip
-    end
-    cleaned
   end
 
   def self.generate_name_candidates(name_param, email) # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="container mt-1">
   <div class="dash-box mx-2 my-3">
-    <h1><%= time_based_greeting(current_user.name) %> <%= time_based_emoji %></h1>
+    <h1><%= time_based_greeting(current_user.name) %> <%= time_based_emoji %></h1>
     <div class="my-3">
       <h3><%= t('dashboard.happy_streak') %></h3>
       <p><%= pluralize(current_user.happy_streak, 'day') %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
                     label: false,
                     placeholder: t('sessions.email_placeholder'),
                     input_html: {
-                      autocomplete: "email",
+                      autocomplete: "username",
                       class: "login-page__input",
                       aria: { label: t('sessions.email_placeholder') }
                     } %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,39 +1,51 @@
-<div class="login-page">
-  <div class="login-page__content">
-    <h2 class="login-page__title">Welcome back, little human! 👋</h2>
+<div class="homepage-container login-page">
+  <div class="homepage-content">
+    <div class="logo-home">
+      <%= image_tag "five.png", alt: t("layouts.logo_alt") %>
+    </div>
 
-    <div class="login-card">
+    <h1 class="homepage-title login-page__headline"><%= t('sessions.welcome_back', emoji: login_wave_emoji) %></h1>
+
+    <div class="login-page__form">
       <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <%= f.input :email,
                     required: false,
                     autofocus: true,
                     label: false,
-                    placeholder: "Email",
-                    input_html: { autocomplete: "email", class: "login-card__input" } %>
+                    placeholder: t('sessions.email_placeholder'),
+                    input_html: {
+                      autocomplete: "email",
+                      class: "login-page__input",
+                      aria: { label: t('sessions.email_placeholder') }
+                    } %>
         <% unless Rails.env.development? %>
           <%= f.input :password,
                       required: false,
                       label: false,
-                      placeholder: "Password",
-                      input_html: { autocomplete: "current-password", class: "login-card__input" } %>
+                      placeholder: t('sessions.password_placeholder'),
+                      input_html: {
+                        autocomplete: "current-password",
+                        class: "login-page__input",
+                        aria: { label: t('sessions.password_placeholder') }
+                      } %>
         <% end %>
 
         <%= f.button :submit, t('sessions.log_in'),
-            class: "login-card__btn",
+            class: "homepage-btn homepage-btn--primary login-page__submit",
             data: { turbo: false } %>
       <% end %>
     </div>
 
     <%- if devise_mapping.omniauthable? %>
       <div class="login-page__divider">
-        <span>or</span>
+        <span><%= t('sessions.or') %></span>
       </div>
 
       <div class="login-page__social">
         <%- resource_class.omniauth_providers.each do |provider| %>
           <% if provider == :google_oauth2 %>
             <%= form_for "Login", url: omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: "false" } do |f| %>
-              <button type="submit" class="login-google-btn" aria-label="Sign in with Google">
+              <button type="submit" class="login-google-btn" aria-label="<%= t('sessions.sign_in_with_google') %>">
                 <%# Google "G" logo (red, blue, yellow, green segments) %>
                 <svg viewBox="0 0 48 48" width="24" height="24">
                   <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -50,10 +62,10 @@
 
     <div class="login-page__footer">
       <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-        <%= link_to "Sign up", onboarding_path %>
+        <%= link_to t('registration.sign_up'), onboarding_path, class: "login-page__footer-link" %>
       <% end %>
       <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-        <%= link_to "Forgot password?", new_password_path(resource_name) %>
+        <%= link_to t('sessions.forgot_password'), new_password_path(resource_name), class: "login-page__footer-link" %>
       <% end %>
     </div>
   </div>

--- a/app/views/happy_things/future_root.html.erb
+++ b/app/views/happy_things/future_root.html.erb
@@ -1,6 +1,6 @@
 <div class="container mt-1 future-root-container" data-controller="insert-in-list">
   <div class="dash-box mx-2 my-3">
-    <h1><%= time_based_greeting(current_user ? current_user.name : (session[:guest_onboarding]&.dig('name') || "Sunshine")) %> <%= time_based_emoji %></h1>
+    <h1><%= time_based_greeting(current_user&.name || session[:guest_onboarding]&.dig('name')) %> <%= time_based_emoji %></h1>
     <% if current_user %>
       <div class="my-3">
         <h3><%= t('dashboard.happy_streak') %></h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Five Things</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,7 +2,7 @@
   <div class="homepage-content">
 
     <div class="logo-home">
-      <%= image_tag "five.png", alt: "Five Things Logo" %>
+      <%= image_tag "five.png", alt: t("layouts.logo_alt") %>
     </div>
 
     <h1 class="homepage-title">What made you happy today?</h1>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -68,6 +68,7 @@ de:
 
   dashboard:
     greetings:
+      default_name: "Sonnenschein"
       go_to_bed: "Geh schlafen, du freches Ding!"
       good_morning: "Guten Morgen, %{name}"
       good_evening: "Guten Abend, %{name}"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,7 @@
 de:
+  layouts:
+    logo_alt: "Five Things Logo"
+
   simple_form:
     placeholders:
       happy_thing:
@@ -25,6 +28,12 @@ de:
 
   sessions:
     log_in: "Einloggen"
+    welcome_back: "Willkommen zurück, du kleiner Mensch! %{emoji}"
+    email_placeholder: "E-Mail"
+    password_placeholder: "Passwort"
+    or: "oder"
+    forgot_password: "Passwort vergessen?"
+    sign_in_with_google: "Mit Google anmelden"
     user_not_found: "Benutzer*in mit E-Mail %{email} nicht gefunden"
 
   nav:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  layouts:
+    logo_alt: "Five Things Logo"
+
   simple_form:
     placeholders:
       happy_thing:
@@ -31,6 +34,12 @@ en:
           length: "must be between 3 and 255 characters long"
   sessions:
     log_in: "Log in"
+    welcome_back: "Welcome back, little human! %{emoji}"
+    email_placeholder: "Email"
+    password_placeholder: "Password"
+    or: "or"
+    forgot_password: "Forgot password?"
+    sign_in_with_google: "Sign in with Google"
     user_not_found: "User with email %{email} not found"
 
   nav:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
 
   dashboard:
     greetings:
+      default_name: "Sunshine"
       go_to_bed: "Go to bed naughty!"
       good_morning: "Good Morning, %{name}"
       good_evening: "Good Evening, %{name}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -68,7 +68,7 @@ sv:
 
   dashboard:
     greetings:
-      default_name: "Solstråle"
+      default_name: "Solsken"
       go_to_bed: "Gå och lägg dig, stygga!"
       good_morning: "God morgon, %{name}"
       good_evening: "God kväll, %{name}"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,4 +1,7 @@
 sv:
+  layouts:
+    logo_alt: "Five Things Logo"
+
   simple_form:
     placeholders:
       happy_thing:
@@ -25,6 +28,12 @@ sv:
 
   sessions:
     log_in: "Logga in"
+    welcome_back: "Välkommen tillbaka, lilla människa! %{emoji}"
+    email_placeholder: "E-post"
+    password_placeholder: "Lösenord"
+    or: "eller"
+    forgot_password: "Glömt lösenordet?"
+    sign_in_with_google: "Logga in med Google"
     user_not_found: "Användare med e-post %{email} hittades inte"
 
   nav:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -68,6 +68,7 @@ sv:
 
   dashboard:
     greetings:
+      default_name: "Solstråle"
       go_to_bed: "Gå och lägg dig, stygga!"
       good_morning: "God morgon, %{name}"
       good_evening: "God kväll, %{name}"

--- a/db/migrate/20260713120000_add_notified_friends_on_to_users.rb
+++ b/db/migrate/20260713120000_add_notified_friends_on_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotifiedFriendsOnToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :notified_friends_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_01_210925) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,6 +46,28 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_01_210925) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "close_friends_issues", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.datetime "published_at"
+    t.datetime "sent_at"
+    t.bigint "created_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_close_friends_issues_on_created_by_id"
+  end
+
+  create_table "close_friends_subscribers", force: :cascade do |t|
+    t.string "email", null: false
+    t.datetime "confirmed_at"
+    t.datetime "approved_at"
+    t.datetime "unsubscribed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.index ["email"], name: "index_close_friends_subscribers_on_email", unique: true
   end
 
   create_table "comments", force: :cascade do |t|
@@ -143,6 +165,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_01_210925) do
     t.string "uid"
     t.string "timezone", default: "UTC"
     t.string "locale", default: "en", null: false
+    t.date "notified_friends_on"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -150,6 +173,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_01_210925) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "close_friends_issues", "users", column: "created_by_id"
   add_foreign_key "comments", "happy_things"
   add_foreign_key "comments", "users"
   add_foreign_key "friendships", "users"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,9 @@
+# Deployment
+
+1. Precompile assets:
+
+   ```bash
+   rails assets:precompile
+   ```
+
+2. Deploy to your hosting platform (see platform-specific configuration in the repo).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,92 @@
+# Getting started
+
+These instructions get the project running on your local machine.
+
+## Prerequisites
+
+- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 3.4.4
+- [Rails](https://guides.rubyonrails.org/) 8.0.3
+- PostgreSQL
+
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/emmvs/five_things.git
+   cd five_things
+   ```
+
+2. Install gems:
+
+   ```bash
+   bundle install
+   ```
+
+3. Install and start PostgreSQL:
+
+   ```bash
+   brew install postgresql
+   brew services start postgresql
+   ```
+
+## Database
+
+```bash
+rails db:create
+rails db:migrate
+rails db:seed
+```
+
+## Development server
+
+**Option 1: Foreman (recommended)**
+
+Starts Rails and ngrok together:
+
+```bash
+bin/dev
+```
+
+- Rails: `http://localhost:3000`
+- ngrok URL appears in the logs (for mobile testing)
+
+**Option 2: Manual (recommended for `binding.pry`)**
+
+Terminal 1:
+
+```bash
+rails s
+```
+
+Terminal 2:
+
+```bash
+ngrok http 3000
+```
+
+Use the ngrok forwarding URL on your phone. URLs may end in `.app`, `.dev`, or `.io` depending on your ngrok account.
+
+## Testing
+
+```bash
+rspec                              # full suite
+rspec spec/requests/users_spec.rb  # single file
+```
+
+## Linting & security
+
+```bash
+bundle exec rubocop
+bundle exec brakeman -q -w2
+```
+
+CI runs RuboCop and Brakeman on every push and PR to `main` (see `.github/workflows/ci.yml`).
+
+## Environment variables
+
+Secrets must never be committed. Use `.env` locally (git-ignored) and add new keys to `.env.sample` with empty values. Access them in code via `ENV.fetch("VAR_NAME")` or Rails credentials.
+
+## Services
+
+- **Poetry service** — fetches a random poem for the dashboard quote.

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -21,5 +21,21 @@ RSpec.describe DashboardHelper, type: :helper do
         I18n.t('dashboard.greetings.good_morning', name: 'Emma')
       )
     end
+
+    it 'strips repeated leading comma and space patterns' do
+      allow(helper).to receive(:current_hour_in).and_return(8)
+
+      expect(helper.time_based_greeting(', , Emma')).to eq(
+        I18n.t('dashboard.greetings.good_morning', name: 'Emma')
+      )
+    end
+
+    it 'uses a fallback name when the display name is blank' do
+      allow(helper).to receive(:current_hour_in).and_return(8)
+
+      expect(helper.time_based_greeting(',,')).to eq(
+        I18n.t('dashboard.greetings.good_morning', name: I18n.t('dashboard.greetings.default_name'))
+      )
+    end
   end
 end

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DashboardHelper, type: :helper do
+  describe '#time_based_greeting' do
+    before { I18n.locale = :en }
+
+    it 'does not duplicate commas when the name has a leading comma' do
+      allow(helper).to receive(:current_hour_in).and_return(8)
+
+      expect(helper.time_based_greeting(', Emma')).to eq(
+        I18n.t('dashboard.greetings.good_morning', name: 'Emma')
+      )
+    end
+
+    it 'strips trailing commas from the name' do
+      allow(helper).to receive(:current_hour_in).and_return(8)
+
+      expect(helper.time_based_greeting('Emma,,')).to eq(
+        I18n.t('dashboard.greetings.good_morning', name: 'Emma')
+      )
+    end
+  end
+end

--- a/spec/models/happy_thing_spec.rb
+++ b/spec/models/happy_thing_spec.rb
@@ -40,24 +40,55 @@ RSpec.describe HappyThing, type: :model do
   end
 
   describe 'Callbacks' do
-    context 'when a user adds 5 happy things in a day' do
-      it 'sends an email to each of their friends' do
-        user = create(:user)
-        friends = create_list(:user, 3)
+    def create_friendships(user, friends)
+      friends.each do |friend|
+        create(:friendship, user:, friend:, accepted: true)
+      end
+    end
 
-        # With bidirectional friendships, creating one friendship creates both records
-        friends.each do |friend|
-          create(:friendship, user:, friend:, accepted: true)
-        end
+    def delivered_recipients
+      ActionMailer::Base.deliveries.map(&:to).flatten
+    end
+
+    context 'when a user adds 5 happy things in a day' do
+      it 'sends exactly one email to each opted-in friend' do
+        user = create(:user)
+        friends = create_list(:user, 3, email_opt_in: true)
+        create_friendships(user, friends)
 
         perform_enqueued_jobs do
           create_list(:happy_thing, 5, user:)
         end
 
-        delivered_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+        delivered_emails = delivered_recipients
 
+        expect(delivered_emails.size).to eq(3)
         friends.each do |friend|
-          expect(delivered_emails).to include(friend.email)
+          expect(delivered_emails.count(friend.email)).to eq(1)
+        end
+        expect(user.reload.friends_notified_today?).to be(true)
+      end
+
+      it 'does not notify friends again after deleting and re-adding a happy thing the same day' do
+        user = create(:user)
+        friends = create_list(:user, 2, email_opt_in: true)
+        create_friendships(user, friends)
+
+        perform_enqueued_jobs do
+          create_list(:happy_thing, 5, user:)
+        end
+
+        expect(delivered_recipients.size).to eq(2)
+
+        user.happy_things.last.destroy
+
+        perform_enqueued_jobs do
+          create(:happy_thing, user:)
+        end
+
+        expect(delivered_recipients.size).to eq(2)
+        friends.each do |friend|
+          expect(delivered_recipients.count(friend.email)).to eq(1)
         end
       end
     end
@@ -66,15 +97,21 @@ RSpec.describe HappyThing, type: :model do
   describe 'Mailers' do
     before { clear_enqueued_jobs }
 
-    it 'sends an email to each of their friends but not to non-friends' do
-      user = create(:user)
-      friends = create_list(:user, 3)
-      non_friend = create(:user)
-
-      # With bidirectional friendships, creating one friendship creates both records
+    def create_friendships(user, friends)
       friends.each do |friend|
         create(:friendship, user:, friend:, accepted: true)
       end
+    end
+
+    def delivered_recipients
+      ActionMailer::Base.deliveries.map(&:to).flatten
+    end
+
+    it 'sends an email to each opted-in friend but not to non-friends' do
+      user = create(:user)
+      friends = create_list(:user, 3, email_opt_in: true)
+      non_friend = create(:user, email_opt_in: true)
+      create_friendships(user, friends)
 
       create_list(:happy_thing, 4, user:)
 
@@ -82,13 +119,31 @@ RSpec.describe HappyThing, type: :model do
         create(:happy_thing, user:)
       end
 
-      delivered_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+      delivered_emails = delivered_recipients
 
+      expect(delivered_emails.size).to eq(3)
       friends.each do |friend|
-        expect(delivered_emails).to include(friend.email)
+        expect(delivered_emails.count(friend.email)).to eq(1)
       end
 
       expect(delivered_emails).not_to include(non_friend.email)
+    end
+
+    it 'does not send emails to friends who have not opted in' do
+      user = create(:user)
+      opted_in_friend = create(:user, email_opt_in: true)
+      opted_out_friend = create(:user, email_opt_in: false)
+      create_friendships(user, [opted_in_friend, opted_out_friend])
+
+      perform_enqueued_jobs do
+        create_list(:happy_thing, 5, user:)
+      end
+
+      delivered_emails = delivered_recipients
+
+      expect(delivered_emails.size).to eq(1)
+      expect(delivered_emails).to eq([opted_in_friend.email])
+      expect(delivered_emails).not_to include(opted_out_friend.email)
     end
 
     after { clear_performed_jobs }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,6 +195,10 @@ RSpec.describe User, type: :model do
       expect(User.extract_name('Emma Who', 'emmazing@gmail.com')).to eq('Emma')
     end
 
+    it 'strips trailing commas from OAuth-style last names' do
+      expect(User.extract_name('Smith, John', 'john.smith@gmail.com')).to eq('Smith')
+    end
+
     it 'returns full name if first word is too short' do
       expect(User.extract_name('I love rspec 🥳', 'email@gmail.com')).to eq('I love rspec 🥳')
       expect(User.extract_name('A. B. B. A.', 'email@gmail.com')).to eq('A. B. B. A.')


### PR DESCRIPTION
## Summary
- Fixes dashboard greeting edge cases where stray commas produced broken greetings like `,,`
- Improves OAuth name parsing and adds a fallback display name for empty values
- Updates login page styling and uses `autocomplete="username"` for better iOS Keychain behavior
- Restructures README and moves setup/deployment instructions into `docs/`